### PR TITLE
pyproject.toml: remove unused ignore-list entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -339,7 +339,7 @@ disable = [
 ]
 
 [tool.codespell]
-ignore-words-list = "afile,asend,asser,assertio,feld,hove,ned,noes,notin,paramete,parth,socio-economic,tesults,varius,wil"
+ignore-words-list = "afile,asend,asser,assertio,feld,hove,ned,noes,notin,paramete,parth,tesults,varius,wil"
 skip = "AUTHORS,*/plugin_list.rst"
 write-changes = true
 


### PR DESCRIPTION
The term `socio-economic` does not appear to be autocorrected by recent versions of `codespell`.  The term [appears in `pytest`'s Code of Conduct](https://github.com/pytest-dev/pytest/blob/315b3ae798fe38264b3ab2312dced212c46f1e21/CODE_OF_CONDUCT.md?plain=1#L3-L10), and in the [configured list of ignored-corrections](https://github.com/pytest-dev/pytest/blob/315b3ae798fe38264b3ab2312dced212c46f1e21/pyproject.toml#L342); I believe we can remove it from the ignored word list.

Tested with version 2.4.1 of `codespell` (and via `pre-commit`).

Observed during code upgrade review from [`8.3.5...8.4.0`](https://github.com/pytest-dev/pytest/compare/8.3.5...8.4.0), specifically of #12769.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [ ] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

cc @cclauss